### PR TITLE
Do not hard code page title - breaks search engine optimization

### DIFF
--- a/theme/main.html
+++ b/theme/main.html
@@ -1,8 +1,16 @@
 {% extends "base.html" %}
 
-{% block htmltitle %}
-  <title>NHUG</title>
-{% endblock %}
+<!-- include page short_title *after* site name, if it exists, and fall back to page title -->
+{%- block htmltitle %}
+<title>
+  {{ config.site_name }}
+   {%- if page and page.meta and page.meta.short_title and not page.is_homepage %}
+  - {{ page.meta.short_title }}
+  {%- elif page and page.title and not page.is_homepage %}
+  - {{ page.title }}
+  {%- endif %}
+</title>
+{%- endblock %}
 
 
 <!-- Announcement bar -->


### PR DESCRIPTION
Each page is currently showing up with an HTML title "NHUG", which breaks analysis of user traffic or search engine discovery since both rely on unique HTML page headers.

Backport the `html` title from the common repo.
